### PR TITLE
Fix monitoring script paths, imports and psutil syntax; update docs

### DIFF
--- a/docs/使用說明.md
+++ b/docs/使用說明.md
@@ -12,9 +12,9 @@
 - `config.yaml` - 統一配置文件，管理所有系統參數
 
 ### 📊 監控系統
-- `maple/monitor.py` - 基礎進程監控腳本
-- `maple/monitor_plus.py` - 增強版監控系統，支援性能分析和圖表生成
-- `maple/quick_status.py` - 快速狀態檢查工具
+- `monitoring/monitor.py` - 基礎進程監控腳本
+- `monitoring/monitor_plus.py` - 增強版監控系統，支援性能分析和圖表生成
+- `monitoring/quick_status.py` - 快速狀態檢查工具
 
 ### 🤖 模型文件
 - `weights/best.pt` - 主要訓練模型 (6.2MB)
@@ -128,7 +128,7 @@ safety:
 ### 📈 監控功能
 ```bash
 # 啟動增強監控
-python maple/monitor_plus.py
+python monitoring/monitor_plus.py
 
 # 功能選單:
 # 1. 實時監控 - 持續監控系統狀態
@@ -165,7 +165,7 @@ project/
 │   ├── best.pt                # 主要模型
 │   ├── last.pt                # 備用模型
 │   └── best.onnx              # ONNX 模型
-├── maple/                      # 監控系統目錄
+├── monitoring/                 # 監控系統目錄
 │   ├── monitor.py             # 基礎監控
 │   ├── monitor_plus.py        # 增強監控
 │   ├── quick_status.py        # 快速狀態

--- a/docs/監控系統說明.md
+++ b/docs/監控系統說明.md
@@ -12,16 +12,16 @@
 
 ## 文件說明
 
-- `monitor.py` - 主要監控程式
-- `quick_status.py` - 快速狀態檢查
-- `test_monitor.py` - 功能測試腳本
+- `monitoring/monitor.py` - 主要監控程式
+- `monitoring/quick_status.py` - 快速狀態檢查
+- `tools/test_monitor.py` - 功能測試腳本
 - `auto.py` - 遊戲自動化腳本 (使用 YOLO 模型)
 
 ## 使用方法
 
 ### 1. 快速狀態檢查
 ```bash
-python3 quick_status.py
+python3 monitoring/quick_status.py
 ```
 立即顯示 MapleStory Worlds 的當前狀態，包括：
 - 進程數量和狀態
@@ -31,7 +31,7 @@ python3 quick_status.py
 
 ### 2. 完整監控功能
 ```bash
-python3 monitor.py
+python3 monitoring/monitor.py
 ```
 啟動互動式監控程式，提供以下選項：
 - **選項 1**: 開始實時監控 (可設定更新間隔)
@@ -40,7 +40,7 @@ python3 monitor.py
 
 ### 3. 測試功能
 ```bash
-python3 test_monitor.py
+python3 tools/test_monitor.py
 ```
 測試所有監控功能是否正常運作。
 
@@ -76,7 +76,7 @@ python3 test_monitor.py
 
 ### 快速檢查遊戲狀態
 ```bash
-$ python3 quick_status.py
+$ python3 monitoring/quick_status.py
 🍁 MapleStory Worlds 快速狀態檢查
 ============================================================
 檢查時間: 2025-06-08 00:52:50
@@ -92,7 +92,7 @@ $ python3 quick_status.py
 
 ### 開始實時監控
 ```bash
-$ python3 monitor.py
+$ python3 monitoring/monitor.py
 🍁 MapleStory Worlds 監控工具
 1. 開始實時監控
 2. 查看摘要報告
@@ -115,4 +115,4 @@ $ python3 monitor.py
 1. 確認 MapleStory Worlds 正在運行
 2. 檢查 Python 和 psutil 是否正確安裝
 3. 查看 `maple_monitor.log` 日誌文件
-4. 運行 `test_monitor.py` 進行功能測試 
+4. 運行 `tools/test_monitor.py` 進行功能測試 

--- a/monitoring/monitor.py
+++ b/monitoring/monitor.py
@@ -5,7 +5,7 @@ MapleStory Worlds 背景監控工具
 實時監控遊戲進程狀態、資源使用情況和運行時間
 """
 
-import psutil  type: ignore
+import psutil  # type: ignore
 import time
 import datetime
 import json

--- a/monitoring/quick_status.py
+++ b/monitoring/quick_status.py
@@ -4,7 +4,7 @@
 MapleStory Worlds 快速狀態檢查
 """
 
-from monitor import MapleStoryMonitor
+from monitoring.monitor import MapleStoryMonitor
 import datetime
 
 def quick_status():

--- a/start.py
+++ b/start.py
@@ -358,10 +358,10 @@ def main():
                 run_script("auto.py", "自動化腳本")
                 
             elif choice == '3':
-                run_script("maple/monitor.py", "監控系統")
+                run_script("monitoring/monitor.py", "監控系統")
                 
             elif choice == '4':
-                run_script("maple/monitor_plus.py", "增強監控系統")
+                run_script("monitoring/monitor_plus.py", "增強監控系統")
                 
             elif choice == '5':
                 quick_test()

--- a/tools/check_optimization.py
+++ b/tools/check_optimization.py
@@ -163,10 +163,10 @@ def main():
     # 檢查監控系統文件
     print("\n📊 監控系統文件:")
     monitoring_files = {
-        "maple/monitor.py": "基礎監控",
-        "maple/monitor_plus.py": "增強監控",
-        "maple/quick_status.py": "快速狀態",
-        "maple/使用說明.md": "更新的使用說明"
+        "monitoring/monitor.py": "基礎監控",
+        "monitoring/monitor_plus.py": "增強監控",
+        "monitoring/quick_status.py": "快速狀態",
+        "docs/使用說明.md": "更新的使用說明"
     }
     
     for file_path, description in monitoring_files.items():

--- a/tools/test_monitor.py
+++ b/tools/test_monitor.py
@@ -4,7 +4,7 @@
 測試MapleStory Worlds監控功能
 """
 
-from monitor import MapleStoryMonitor
+from monitoring.monitor import MapleStoryMonitor
 import json
 
 def test_monitor():


### PR DESCRIPTION
### Motivation
- The launcher and system-check scripts referenced `maple/` paths that no longer exist, preventing the monitoring tools from being started by `start.py` and detected by checks.
- `monitoring/monitor.py` contained an invalid `psutil` comment syntax that caused a syntax/import error.
- Several helper scripts and documentation still referenced old paths and test commands, causing confusion and failing imports for `test_monitor.py` and `quick_status.py`.

### Description
- Replaced the invalid line `import psutil  type: ignore` with `import psutil  # type: ignore` in `monitoring/monitor.py` to fix the syntax error.
- Updated `start.py` to run `monitoring/monitor.py` and `monitoring/monitor_plus.py` instead of the obsolete `maple/` locations.
- Changed imports to use `from monitoring.monitor import MapleStoryMonitor` in `monitoring/quick_status.py` and `tools/test_monitor.py` so tests and quick status use the correct module path.
- Updated `tools/check_optimization.py` to check the `monitoring/` files and `docs/使用說明.md`, and revised `docs/使用說明.md` and `docs/監控系統說明.md` to reference the `monitoring/` directory and `tools/test_monitor.py` where appropriate.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68465d258f70833089ca436cb572482a)